### PR TITLE
Fix Author Endpoint

### DIFF
--- a/backend/apiviews/author_views.py
+++ b/backend/apiviews/author_views.py
@@ -24,9 +24,17 @@ import json
 
 class AuthorViewSet(viewsets.ViewSet):
 
-    def get_authors(self, request, *args, **kwargs):
+    def get_local_authors(self, request, *args, **kwargs):
         '''
-        Get all the authors
+        Get all the authors on our server
+        '''
+        author = User.objects.all()
+        serializer = UserSerializer(author, many=True)
+        return Response(serializer.data)
+    
+    def get_all_authors(self, request, *args, **kwargs):
+        '''
+        Get all the authors (local and remote)
         '''
         foreign_author = []
         for host in Host.objects.all():

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -71,7 +71,11 @@ urlpatterns = [
 
     # url of Author Operations
     path('author', AuthorViewSet.as_view({
-        "get": "get_authors"
+        "get": "get_local_authors"
+    })),
+
+    path('author/all/', AuthorViewSet.as_view({
+        "get": "get_all_authors"
     })),
 
     # get current authenticated user information


### PR DESCRIPTION
Before it was causing an infinite loop. Just return our local authors for `/author` and created a new endpoint `/author/all/` to get all the authors (only for us)