### PR TITLE
Unlisted post cleanup

### DIFF
--- a/src/components/post/EditablePost.jsx
+++ b/src/components/post/EditablePost.jsx
@@ -65,6 +65,7 @@ class EditablePost extends Component {
         title: image.name,
         visibility: "PUBLIC",
         content_type: `${fileType};base64`,
+        unlisted: true,
       };
 
       postService.createUserPosts(imageData).then((response) => {

--- a/src/components/post/EditablePost.jsx
+++ b/src/components/post/EditablePost.jsx
@@ -180,7 +180,6 @@ class EditablePost extends Component {
             onHide={this.togglePreviewModalVisibility}
             postTitle={postTitle}
             postContent={postContent}
-            imageObjectUrl={postImage}
           />
           <PrivacySelectorModal
             show={privacyModalVisibility}

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -29,7 +29,6 @@ class Post extends Component {
   renderMenu = () => {
     const {
       post,
-      invisible,
       previewMode,
       onEdit,
       onDelete,
@@ -49,7 +48,7 @@ class Post extends Component {
       <div className="post-info">
         <span className="post-user-and-visibility">
           {post.username}
-          { invisible ? <VisibilityOffIcon fontSize="inherit" /> : null }
+          { post.unlisted ? <VisibilityOffIcon className="unlisted-icon" fontSize="inherit" /> : null }
         </span>
         <DropdownButton
           id="post-more-button"
@@ -220,8 +219,8 @@ Post.propTypes = {
     content: PropTypes.string,
     comments: PropTypes.array,
     isGithubPost: PropTypes.bool,
+    unlisted: PropTypes.bool,
   }).isRequired,
-  invisible: PropTypes.bool,
   previewMode: PropTypes.bool,
   onEdit: PropTypes.func,
   onDelete: PropTypes.func,
@@ -229,7 +228,6 @@ Post.propTypes = {
 };
 
 Post.defaultProps = {
-  invisible: false,
   previewMode: false,
   onEdit: null,
   onDelete: null,

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -48,7 +48,7 @@ class Post extends Component {
       <div className="post-info">
         <span className="post-user-and-visibility">
           {post.username}
-          { post.unlisted ? <VisibilityOffIcon className="unlisted-icon" fontSize="inherit" /> : null }
+          { post.unlisted ? <VisibilityOffIcon className="unlisted-icon" /> : null }
         </span>
         <DropdownButton
           id="post-more-button"

--- a/src/components/post/PostPreviewModal.jsx
+++ b/src/components/post/PostPreviewModal.jsx
@@ -14,11 +14,14 @@ function PostPreviewModal(props) {
 
   // Post requires a Post object for rendering
   const postObj = {
-    id: "-1", // arbitrary ID for the Post object
     title: postTitle,
     content: postContent,
     published: (new Date()).toISOString(),
-    username: "username",
+    // must supply to keep the Prop check happy
+    id: "-1", // arbitrary ID for the Post object
+    username: "",
+    source: "",
+    authorId: "",
   };
 
   return (
@@ -41,11 +44,9 @@ PostPreviewModal.propTypes = {
   onHide: PropTypes.func.isRequired,
   postTitle: PropTypes.string.isRequired,
   postContent: PropTypes.string.isRequired,
-  imageObjectUrl: PropTypes.string,
 };
 
 PostPreviewModal.defaultProps = {
-  imageObjectUrl: "",
 };
 
 export default PostPreviewModal;

--- a/src/components/post/PostView.jsx
+++ b/src/components/post/PostView.jsx
@@ -154,8 +154,8 @@ class PostView extends Component {
       } else if (post.id === editingPostId) {
         // this post is being edited currently
         renderedPosts.push(
-          <Pulse duration={200}>
-            <div className="postWrapper" key={-1}>
+          <Pulse duration={200} key={-1}>
+            <div className="postWrapper">
               <EditablePost
                 editMode
                 originalPost={post}

--- a/src/styles/post/Post.scss
+++ b/src/styles/post/Post.scss
@@ -19,11 +19,11 @@
             top: 0.5pt;
             line-height: 30pt;
             font-size: 14px;
-            svg {
+            .unlisted-icon {
                 position: relative;
-                top: 1.5pt;
-                left: 2pt;
-                height: 100%;
+                top: -1pt;
+                left: 4pt;
+                font-size: 13pt;
             }
             .github-icon {
                 width: 20px;

--- a/src/tests/components/post/__snapshots__/EditablePost.test.jsx.snap
+++ b/src/tests/components/post/__snapshots__/EditablePost.test.jsx.snap
@@ -20,7 +20,6 @@ exports[`Post box Component should render correctly 1`] = `
       show={false}
     />
     <PostPreviewModal
-      imageObjectUrl=""
       onHide={[Function]}
       postContent=""
       postTitle=""


### PR DESCRIPTION
Fix #219  
Fix #222 

- unlisted posts now have a visual indicator beside the user name
<img width="609" alt="Screen Shot 2020-04-02 at 6 47 18 PM" src="https://user-images.githubusercontent.com/4590693/78313452-02809b80-7514-11ea-9870-8cc4b73a5061.png">

- uploaded images are now unlisted
- random console warning fixes