### PR TITLE
Lazy load for posts on homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "react-dom": "^16.12.0",
         "react-dropzone": "^10.2.1",
         "react-icons": "^3.9.0",
+        "react-infinite-scroller": "^1.2.4",
         "react-markdown": "^4.3.1",
         "react-reveal": "^1.2.2",
         "react-router-dom": "^5.1.2",

--- a/src/components/Homepage.jsx
+++ b/src/components/Homepage.jsx
@@ -20,7 +20,7 @@ class Homepage extends Component {
     // eslint-disable-next-line no-console
     postService.createUserPosts(post).then((response) => {
       if (response.success) {
-        this.child.current.loadPosts();
+        this.child.current.reloadPosts();
       }
     }).catch((error) => {
       // eslint-disable-next-line no-alert

--- a/src/components/post/Post.jsx
+++ b/src/components/post/Post.jsx
@@ -43,7 +43,7 @@ class Post extends Component {
 
     const dropdownIcon = <img id="post-more-icon" src={moreIcon} alt="more-icon" />;
     const formattedTime = moment(post.published).fromNow();
-    const sharableLink = `${window.location.href}share/posts/${post.id}`;
+    const sharableLink = `${(new URL(window.location.href)).origin}/share/posts/${post.id}`;
     const postURL = new URL(post.source);
     const postHost = `${postURL.protocol}//${postURL.host}/`;
 

--- a/src/components/post/PostView.jsx
+++ b/src/components/post/PostView.jsx
@@ -28,24 +28,9 @@ class PostView extends Component {
     const { postId } = this.props;
 
     postService.getSinglePost(postId).then((post) => {
-      const singlePost = post;
-      const newPost = {};
-      const posts = [];
-
-      newPost.username = singlePost.author.displayName;
-      newPost.authorId = singlePost.author.id;
-      newPost.title = singlePost.title;
-      newPost.content = singlePost.content;
-      newPost.published = singlePost.published;
-      newPost.id = singlePost.id;
-      newPost.source = singlePost.source;
-      newPost.comments = singlePost.comments || [];
-      newPost.isGithubPost = singlePost.isGithubPost || false;
-
-      posts.push(newPost);
-
+      const parsedPosts = this.parsePosts([post]);
       this.setState({
-        posts,
+        posts: parsedPosts,
       });
     }).catch(() => (
       <p>Not a Post</p>
@@ -156,6 +141,16 @@ class PostView extends Component {
   render() {
     const { editingPostId, posts, hasMoreItems } = this.state;
 
+    const { postId } = this.props;
+    if (postId && posts.length > 0) {
+      return (
+        <Post
+          post={posts[0]}
+          previewMode
+        />
+      );
+    }
+
     const renderedPosts = [];
     for (let i = 0; i < posts.length; i += 1) {
       const post = posts[i];
@@ -201,17 +196,6 @@ class PostView extends Component {
           </div>,
         );
       }
-    }
-
-    const { postId } = this.props;
-    if (postId) {
-      // don't render the infinite scroll for a single post
-      // this is for when the user visits the share link
-      return (
-        <div className="post-view" key={-1}>
-          {renderedPosts}
-        </div>
-      );
     }
 
     return (

--- a/src/components/post/PostView.jsx
+++ b/src/components/post/PostView.jsx
@@ -79,7 +79,7 @@ class PostView extends Component {
     return parsedPosts;
   }
 
-  loadPosts = (page) => {
+  loadMorePosts = (page) => {
     const { userId } = this.props;
     const { posts } = this.state;
 
@@ -203,12 +203,23 @@ class PostView extends Component {
       }
     }
 
+    const { postId } = this.props;
+    if (postId) {
+      // don't render the infinite scroll for a single post
+      // this is for when the user visits the share link
+      return (
+        <div className="post-view" key={-1}>
+          {renderedPosts}
+        </div>
+      );
+    }
+
     return (
       <Fade bottom duration={1000} distance="100px">
         <div className="post-view" key={-1}>
           <InfiniteScroll
             pageStart={0}
-            loadMore={this.loadPosts}
+            loadMore={this.loadMorePosts}
             hasMore={hasMoreItems}
             loader={<div className="loader" key={0}>Loading ...</div>}
           >

--- a/src/components/post/PostView.jsx
+++ b/src/components/post/PostView.jsx
@@ -5,6 +5,7 @@ import Fade from "react-reveal/Fade";
 import Pulse from "react-reveal/Pulse";
 import InfiniteScroll from "react-infinite-scroller";
 import "../../styles/post/PostView.scss";
+import Spinner from "react-bootstrap/Spinner";
 import EditablePost from "./EditablePost";
 import Post from "./Post";
 import GithubPost from "./GithubPost";
@@ -205,7 +206,7 @@ class PostView extends Component {
             pageStart={0}
             loadMore={this.loadMorePosts}
             hasMore={hasMoreItems}
-            loader={<div className="loader" key={0}>Loading ...</div>}
+            loader={<div className="spinner-wrapper"><Spinner size="sm" animation="border" variant="primary" /></div>}
           >
             {renderedPosts}
           </InfiniteScroll>

--- a/src/components/post/PostView.jsx
+++ b/src/components/post/PostView.jsx
@@ -25,19 +25,6 @@ class PostView extends Component {
     }
   }
 
-  loadSinglePost() {
-    const { postId } = this.props;
-
-    postService.getSinglePost(postId).then((post) => {
-      const parsedPosts = this.parsePosts([post]);
-      this.setState({
-        posts: parsedPosts,
-      });
-    }).catch(() => (
-      <p>Not a Post</p>
-    ));
-  }
-
   parsePosts = (posts) => {
     const parsedPosts = [];
 
@@ -63,6 +50,21 @@ class PostView extends Component {
     }
 
     return parsedPosts;
+  }
+
+  loadSinglePost() {
+    // for rendering when visitng the share link
+    const { postId } = this.props;
+
+    postService.getSinglePost(postId).then((post) => {
+      const parsedPosts = this.parsePosts([post]);
+      this.setState({
+        posts: parsedPosts,
+      });
+    }).catch(() => {
+      // eslint-disable-next-line no-alert
+      console.log("Not a post");
+    });
   }
 
   loadMorePosts = (page) => {
@@ -143,13 +145,19 @@ class PostView extends Component {
     const { editingPostId, posts, hasMoreItems } = this.state;
 
     const { postId } = this.props;
-    if (postId && posts.length > 0) {
-      return (
-        <Post
-          post={posts[0]}
-          previewMode
-        />
-      );
+    if (postId) {
+      // this is very bad code but this if statement can't be combined with the previous one or else it will load
+      // the infinite scroll while this post is still loading
+      if (posts.length > 0) {
+        return (
+          <Post
+            post={posts[0]}
+            previewMode
+          />
+        );
+      }
+
+      return <div className="spinner-wrapper"><Spinner size="sm" animation="border" variant="primary" /></div>;
     }
 
     const renderedPosts = [];
@@ -200,12 +208,13 @@ class PostView extends Component {
     }
 
     return (
-      <Fade bottom duration={1000} distance="100px">
+      <Fade bottom duration={2500} distance="50px">
         <div className="post-view" key={-1}>
           <InfiniteScroll
             pageStart={0}
             loadMore={this.loadMorePosts}
             hasMore={hasMoreItems}
+            threshold={500}
             loader={<div className="spinner-wrapper"><Spinner size="sm" animation="border" variant="primary" /></div>}
           >
             {renderedPosts}

--- a/src/services/PostService.jsx
+++ b/src/services/PostService.jsx
@@ -16,6 +16,20 @@ export const getPosts = () => {
   });
 };
 
+export const getPostsByPage = (page) => {
+  return axios.get(`/author/posts?page=${page}&size=10`).then((response) => {
+    if (response.status === 200) {
+      if (response.data && response.data.posts) {
+        return response.data;
+      }
+      return {};
+    }
+
+    throw new Error("Unable to retrieve posts");
+  });
+};
+
+
 export const getSinglePost = (postId) => {
   return axios.get(`/posts/${postId}`).then((response) => {
     if (response.status === 200) {

--- a/src/services/PostService.jsx
+++ b/src/services/PostService.jsx
@@ -16,8 +16,8 @@ export const getPosts = () => {
   });
 };
 
-export const getPostsByPage = (page) => {
-  return axios.get(`/author/posts?page=${page}&size=10`).then((response) => {
+export const getPostsByPage = (page, size) => {
+  return axios.get(`/author/posts?page=${page}&size=${size}`).then((response) => {
     if (response.status === 200) {
       if (response.data && response.data.posts) {
         return response.data;
@@ -72,7 +72,7 @@ export const createUserPosts = (postData) => {
   });
 };
 
-export const deleteUserPosts = (postId) => {
+export const deleteUserPost = (postId) => {
   const csrf = Cookies.get("csrftoken");
   const headers = {
     "X-CSRFToken": csrf,
@@ -87,7 +87,7 @@ export const deleteUserPosts = (postId) => {
   });
 };
 
-export const updateUserPosts = (post) => {
+export const updateUserPost = (post) => {
   const csrf = Cookies.get("csrftoken");
   const headers = {
     "X-CSRFToken": csrf,

--- a/src/styles/post/PostView.scss
+++ b/src/styles/post/PostView.scss
@@ -4,4 +4,9 @@
     .postWrapper {
         padding: 15px 10px;
     }
+
+    .spinner-wrapper {
+        text-align: center;
+        margin-top: 30pt;
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8447,6 +8447,13 @@ react-icons@^3.9.0:
   dependencies:
     camelcase "^5.0.0"
 
+react-infinite-scroller@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-infinite-scroller/-/react-infinite-scroller-1.2.4.tgz#f67eaec4940a4ce6417bebdd6e3433bfc38826e9"
+  integrity sha512-/oOa0QhZjXPqaD6sictN2edFMsd3kkMiE19Vcz5JDgHpzEJVqYcmq+V3mkwO88087kvKGe1URNksHEOt839Ubw==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-input-autosize@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"


### PR DESCRIPTION
Fix #216 
Fix #239 

- load posts by page now instead of all at once 
- scroll down and new posts will load as you scroll
- spinner to indicate that posts are loading
- change the component that renders when visiting a post share link
- fix the share link that is generated on the profile page (didn't work before)
- added a common parser for all the posts instead of doing it in multiple places