### PR TITLE
Allow "www" in the github url

### DIFF
--- a/src/components/profile/EditProfileModal.jsx
+++ b/src/components/profile/EditProfileModal.jsx
@@ -61,7 +61,7 @@ class EditProfileModal extends Component {
         errorGithub = "Invalid github URL.";
       }
       // Check github url format
-      if (urlValidator && (urlValidator.protocol !== "https:" || urlValidator.host !== "github.com")) {
+      if (urlValidator && (urlValidator.protocol !== "https:" || !urlValidator.host.includes("github.com"))) {
         errorGithub = "Invalid github URL.";
       }
     }


### PR DESCRIPTION
Before www.github.com urls were not allowed by the url checker. 